### PR TITLE
Ore system

### DIFF
--- a/Assets/ores_tileset.tres
+++ b/Assets/ores_tileset.tres
@@ -1,0 +1,16 @@
+[gd_resource type="TileSet" load_steps=3 format=3 uid="uid://b6a6bt6p5wqq6"]
+
+[ext_resource type="Texture2D" uid="uid://b05xviclivy3a" path="res://Assets/ores.png" id="1_karn5"]
+
+[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_3kekb"]
+texture = ExtResource("1_karn5")
+0:0/0 = 0
+1:0/0 = 0
+2:0/0 = 0
+3:0/0 = 0
+4:0/0 = 0
+5:0/0 = 0
+6:0/0 = 0
+
+[resource]
+sources/0 = SubResource("TileSetAtlasSource_3kekb")

--- a/Game/data/layer_generation_resource.gd
+++ b/Game/data/layer_generation_resource.gd
@@ -1,0 +1,4 @@
+class_name LayerGenerationResource extends Resource
+
+@export var background_rock: Ore.Type
+@export var ores: Array[OreGenerationResource]

--- a/Game/data/layer_generation_resource.gd.uid
+++ b/Game/data/layer_generation_resource.gd.uid
@@ -1,0 +1,1 @@
+uid://bm22xfid7upsy

--- a/Game/data/ore_generation_resource.gd
+++ b/Game/data/ore_generation_resource.gd
@@ -1,0 +1,5 @@
+class_name OreGenerationResource extends Resource
+
+@export var ore: Ore.Type
+@export var generate_for_all_players: bool
+@export_range(1,20) var size: float

--- a/Game/data/ore_generation_resource.gd.uid
+++ b/Game/data/ore_generation_resource.gd.uid
@@ -1,0 +1,1 @@
+uid://c5q3whbjic2df

--- a/Game/data/ore_resource.gd
+++ b/Game/data/ore_resource.gd
@@ -1,0 +1,6 @@
+extends Resource
+
+class_name OreResource
+
+@export var atlas_coordinates: Vector2i
+@export var item_yield: Item.Type

--- a/Game/data/ore_resource.gd.uid
+++ b/Game/data/ore_resource.gd.uid
@@ -1,0 +1,1 @@
+uid://vkrp2p2gvhjj

--- a/Game/data/ores/copper.tres
+++ b/Game/data/ores/copper.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="OreResource" load_steps=2 format=3 uid="uid://b3jskwobwi3up"]
+
+[ext_resource type="Script" uid="uid://vkrp2p2gvhjj" path="res://Game/data/ore_resource.gd" id="1_lngge"]
+
+[resource]
+script = ExtResource("1_lngge")
+atlas_coordinates = Vector2i(3, 0)
+item_yield = 4

--- a/Game/data/ores/ice.tres
+++ b/Game/data/ores/ice.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="OreResource" load_steps=2 format=3 uid="uid://d2elxt3db652r"]
+
+[ext_resource type="Script" uid="uid://vkrp2p2gvhjj" path="res://Game/data/ore_resource.gd" id="1_gxl26"]
+
+[resource]
+script = ExtResource("1_gxl26")
+atlas_coordinates = Vector2i(5, 0)
+item_yield = 5

--- a/Game/data/ores/iron.tres
+++ b/Game/data/ores/iron.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="OreResource" load_steps=2 format=3 uid="uid://34vesocfe87i"]
+
+[ext_resource type="Script" uid="uid://vkrp2p2gvhjj" path="res://Game/data/ore_resource.gd" id="1_5x48m"]
+
+[resource]
+script = ExtResource("1_5x48m")
+atlas_coordinates = Vector2i(2, 0)
+item_yield = 3

--- a/Game/data/ores/rock.tres
+++ b/Game/data/ores/rock.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="OreResource" load_steps=2 format=3 uid="uid://frqhevb6e22v"]
+
+[ext_resource type="Script" uid="uid://vkrp2p2gvhjj" path="res://Game/data/ore_resource.gd" id="1_hyud4"]
+
+[resource]
+script = ExtResource("1_hyud4")
+atlas_coordinates = Vector2i(1, 0)
+item_yield = 2

--- a/Game/data/ores/silicon.tres
+++ b/Game/data/ores/silicon.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="OreResource" load_steps=2 format=3 uid="uid://dl5753flq5hht"]
+
+[ext_resource type="Script" uid="uid://vkrp2p2gvhjj" path="res://Game/data/ore_resource.gd" id="1_mmxq8"]
+
+[resource]
+script = ExtResource("1_mmxq8")
+atlas_coordinates = Vector2i(4, 0)
+item_yield = 6

--- a/Game/debug_menu.gd
+++ b/Game/debug_menu.gd
@@ -2,8 +2,28 @@ extends MarginContainer
 
 @onready var _PlayerStates := %PlayerStates
 @onready var _ItemDisplay := %ItemDisplay
+@onready var _World := owner
+@onready var _BoardHolder := %BoardHolder
+
+@onready var _SeedText := %SeedText
 
 func _on_cheat_items_add_items(item_type: Item.Type, amount: int) -> void:
 	print("received signal add_items(%s, %s)" % [item_type, amount])
 	_PlayerStates.add_item(item_type, amount)
 	_ItemDisplay.update_counts()
+
+@rpc("any_peer", "call_local", "reliable")
+func _regen_player_boards() -> void:
+	for player_board in _BoardHolder.get_children():
+		player_board.queue_free()
+	
+	if multiplayer.is_server():
+		randomize()
+		_World.set_up_game.rpc(randi())
+
+func _on_regen_world_button_pressed() -> void:
+	_regen_player_boards.rpc()
+
+
+func _on_world_game_ready() -> void:
+	_SeedText.text = "Seed: %d" % _World.world_seed

--- a/Game/mine_layer.gd
+++ b/Game/mine_layer.gd
@@ -1,0 +1,60 @@
+extends MarginContainer
+
+var num_cols: int
+var num_rows: int
+var tile_map_scale: int
+
+@onready var _mine_tiles: TileMapLayer = %MineTiles
+
+class OreCircle:
+	var ore: Ore.Type
+	var center: Vector2
+	var radius: float
+
+	func _init(o, c, r) -> void:
+		ore = o
+		center = c
+		radius = r
+
+func _ready() -> void:
+	_mine_tiles.scale = Vector2i(tile_map_scale, tile_map_scale)
+
+	var tile_size_px = 16 * tile_map_scale
+	custom_minimum_size = Vector2i(0, tile_size_px * num_rows)
+
+func _set_tile(x: int, y: int, ore: Ore.Type) -> void:
+	var tile_pos = Vector2i(x, y)
+	var atlas_coordinates = Ores.get_atlas_coordinates(ore)
+	_mine_tiles.set_cell(tile_pos, 0, atlas_coordinates)
+
+func generate_ores(background_rock: Ore.Type, generation_data: Array) -> void:
+	# first, make a random circle for each ore
+	var ore_circles: Array[OreCircle]
+	for ore_gen_data: OreGenerationResource in generation_data:
+		var ore := ore_gen_data.ore
+		var radius := ore_gen_data.size
+		
+		var random_center := Vector2(
+			randf_range(0, num_cols),
+			randf_range(0, num_rows),
+		)
+		var random_radius := randfn(radius, 0.3)
+		ore_circles.append(OreCircle.new(ore, random_center, random_radius))
+	
+	# then, for each tile in the tilemap
+	for x in range(num_cols):
+		for y in range(num_rows):
+			# find the ore circle that is closest to the tile: this will be the ore we write to the tilemap
+			var center_of_tile := Vector2(x + 0.5, y + 0.5)
+			# if no ore is found, write the background rock
+			var closest_ore := background_rock
+			var closest_distance := 9999.0
+
+			for ore_circle in ore_circles:
+				var dist_to_center := center_of_tile.distance_to(ore_circle.center)
+				if dist_to_center < ore_circle.radius and dist_to_center < closest_distance:
+					closest_ore = ore_circle.ore
+					closest_distance = dist_to_center
+			
+			# set the tile to whatever we did or didn't find
+			_set_tile(x, y, closest_ore)

--- a/Game/mine_layer.gd.uid
+++ b/Game/mine_layer.gd.uid
@@ -1,0 +1,1 @@
+uid://bidjugom0hkvi

--- a/Game/mine_layer.tscn
+++ b/Game/mine_layer.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://drw5syeijuvky"]
+
+[ext_resource type="Script" uid="uid://bidjugom0hkvi" path="res://Game/mine_layer.gd" id="1_17twj"]
+[ext_resource type="TileSet" uid="uid://b6a6bt6p5wqq6" path="res://Assets/ores_tileset.tres" id="1_tnksv"]
+
+[node name="MineLayer" type="MarginContainer"]
+custom_minimum_size = Vector2(100, 224)
+offset_right = 100.0
+offset_bottom = 224.0
+size_flags_vertical = 3
+script = ExtResource("1_17twj")
+
+[node name="MineTiles" type="TileMapLayer" parent="."]
+unique_name_in_owner = true
+scale = Vector2(2, 2)
+tile_set = ExtResource("1_tnksv")

--- a/Game/ore_type.gd
+++ b/Game/ore_type.gd
@@ -1,0 +1,11 @@
+extends Object
+
+class_name Ore
+
+enum Type {
+    ROCK,
+    IRON,
+    COPPER,
+    ICE,
+    SILICON,
+}

--- a/Game/ore_type.gd.uid
+++ b/Game/ore_type.gd.uid
@@ -1,0 +1,1 @@
+uid://uilg3mpxhue2

--- a/Game/ores.gd
+++ b/Game/ores.gd
@@ -1,0 +1,7 @@
+extends Node
+
+@export var ores_tileset: TileSet
+@export var ores_dict: Dictionary[Ore.Type, OreResource]
+
+func get_info(type: Ore.Type) -> OreResource:
+	return ores_dict[type]

--- a/Game/ores.gd
+++ b/Game/ores.gd
@@ -12,3 +12,6 @@ func get_yield(type: Ore.Type) -> Item.Type:
 
 func get_layer_generation_data(layer_num: int) -> LayerGenerationResource:
 	return ores_generation[layer_num]
+
+func get_num_mine_layers() -> int:
+	return ores_generation.size()

--- a/Game/ores.gd
+++ b/Game/ores.gd
@@ -2,6 +2,13 @@ extends Node
 
 @export var ores_tileset: TileSet
 @export var ores_dict: Dictionary[Ore.Type, OreResource]
+@export var ores_generation: Array[LayerGenerationResource]
 
-func get_info(type: Ore.Type) -> OreResource:
-	return ores_dict[type]
+func get_atlas_coordinates(type: Ore.Type) -> Vector2i:
+	return ores_dict[type].atlas_coordinates
+
+func get_yield(type: Ore.Type) -> Item.Type:
+	return ores_dict[type].item_yield
+
+func get_layer_generation_data(layer_num: int) -> LayerGenerationResource:
+	return ores_generation[layer_num]

--- a/Game/ores.gd.uid
+++ b/Game/ores.gd.uid
@@ -1,0 +1,1 @@
+uid://ct1fu05qamaeo

--- a/Game/ores.tscn
+++ b/Game/ores.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://f10pt5hkn0lf"]
+[gd_scene load_steps=16 format=3 uid="uid://f10pt5hkn0lf"]
 
 [ext_resource type="Script" uid="uid://ct1fu05qamaeo" path="res://Game/ores.gd" id="1_8d5xj"]
 [ext_resource type="TileSet" uid="uid://b6a6bt6p5wqq6" path="res://Assets/ores_tileset.tres" id="2_vpk4w"]
@@ -8,6 +8,42 @@
 [ext_resource type="Resource" uid="uid://b3jskwobwi3up" path="res://Game/data/ores/copper.tres" id="6_bkx51"]
 [ext_resource type="Resource" uid="uid://d2elxt3db652r" path="res://Game/data/ores/ice.tres" id="7_0sncd"]
 [ext_resource type="Resource" uid="uid://dl5753flq5hht" path="res://Game/data/ores/silicon.tres" id="8_gsqek"]
+[ext_resource type="Script" uid="uid://bm22xfid7upsy" path="res://Game/data/layer_generation_resource.gd" id="9_2wguw"]
+[ext_resource type="Script" uid="uid://c5q3whbjic2df" path="res://Game/data/ore_generation_resource.gd" id="10_bkx51"]
+
+[sub_resource type="Resource" id="Resource_0sncd"]
+script = ExtResource("10_bkx51")
+ore = 1
+generate_for_all_players = true
+size = 3.0
+metadata/_custom_type_script = "uid://c5q3whbjic2df"
+
+[sub_resource type="Resource" id="Resource_gsqek"]
+script = ExtResource("10_bkx51")
+ore = 4
+generate_for_all_players = true
+size = 3.0
+metadata/_custom_type_script = "uid://c5q3whbjic2df"
+
+[sub_resource type="Resource" id="Resource_0j3rl"]
+script = ExtResource("10_bkx51")
+ore = 2
+generate_for_all_players = false
+size = 1.5
+metadata/_custom_type_script = "uid://c5q3whbjic2df"
+
+[sub_resource type="Resource" id="Resource_6ixry"]
+script = ExtResource("10_bkx51")
+ore = 3
+generate_for_all_players = false
+size = 1.5
+metadata/_custom_type_script = "uid://c5q3whbjic2df"
+
+[sub_resource type="Resource" id="Resource_2dfac"]
+script = ExtResource("9_2wguw")
+background_rock = 0
+ores = Array[ExtResource("10_bkx51")]([SubResource("Resource_0sncd"), SubResource("Resource_gsqek"), SubResource("Resource_0j3rl"), SubResource("Resource_6ixry")])
+metadata/_custom_type_script = "uid://bm22xfid7upsy"
 
 [node name="Ores" type="Node"]
 script = ExtResource("1_8d5xj")
@@ -19,3 +55,4 @@ ores_dict = Dictionary[int, ExtResource("3_i2qth")]({
 3: ExtResource("7_0sncd"),
 4: ExtResource("8_gsqek")
 })
+ores_generation = Array[ExtResource("9_2wguw")]([SubResource("Resource_2dfac")])

--- a/Game/ores.tscn
+++ b/Game/ores.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=9 format=3 uid="uid://f10pt5hkn0lf"]
+
+[ext_resource type="Script" uid="uid://ct1fu05qamaeo" path="res://Game/ores.gd" id="1_8d5xj"]
+[ext_resource type="TileSet" uid="uid://b6a6bt6p5wqq6" path="res://Assets/ores_tileset.tres" id="2_vpk4w"]
+[ext_resource type="Script" uid="uid://vkrp2p2gvhjj" path="res://Game/data/ore_resource.gd" id="3_i2qth"]
+[ext_resource type="Resource" uid="uid://frqhevb6e22v" path="res://Game/data/ores/rock.tres" id="4_xrb0o"]
+[ext_resource type="Resource" uid="uid://34vesocfe87i" path="res://Game/data/ores/iron.tres" id="5_2wguw"]
+[ext_resource type="Resource" uid="uid://b3jskwobwi3up" path="res://Game/data/ores/copper.tres" id="6_bkx51"]
+[ext_resource type="Resource" uid="uid://d2elxt3db652r" path="res://Game/data/ores/ice.tres" id="7_0sncd"]
+[ext_resource type="Resource" uid="uid://dl5753flq5hht" path="res://Game/data/ores/silicon.tres" id="8_gsqek"]
+
+[node name="Ores" type="Node"]
+script = ExtResource("1_8d5xj")
+ores_tileset = ExtResource("2_vpk4w")
+ores_dict = Dictionary[int, ExtResource("3_i2qth")]({
+0: ExtResource("4_xrb0o"),
+1: ExtResource("5_2wguw"),
+2: ExtResource("6_bkx51"),
+3: ExtResource("7_0sncd"),
+4: ExtResource("8_gsqek")
+})

--- a/Game/player_board.gd
+++ b/Game/player_board.gd
@@ -3,9 +3,7 @@ extends Control
 @onready var _VerticalListContainer := %VerticalListContainer
 @onready var _Sky := %Sky
 @onready var _FactoryFloor := %FactoryFloor
-@onready var _Mine := %Mine
 @onready var _PlayerNameLabel := %PlayerNameLabel
-@onready var _MineTiles := %MineTiles
 @onready var _FactoryTiles := %FactoryTiles
 
 # multiplayer properties
@@ -23,7 +21,7 @@ func _ready() -> void:
 		owner_id = 1
 		ConnectionSystem.host_server()
 		
-	var player = ConnectionSystem.get_player(owner_id)
+	player = ConnectionSystem.get_player(owner_id)
 		
 	print("doing ready for %s (%s)" % [player.name, owner_id])
 
@@ -35,13 +33,12 @@ func _ready() -> void:
 	_VerticalListContainer.custom_minimum_size = Vector2i(board_width_px, 0)
 	_Sky.custom_minimum_size = Vector2i(0, SkyHeight)
 	_FactoryFloor.custom_minimum_size = Vector2i(0, layer_height_px)
-	_Mine.custom_minimum_size = Vector2i(0, layer_height_px)
 	_PlayerNameLabel.text = "%s\n(%s)" % [player.name, player.index]
 
 	for x in range(NumCols):
 		for y in range(LayerThickness):
 			var tileCoords := Vector2i(x, y)
-			var randomOreId=randi_range(1,5)
-			
-			_MineTiles.set_cell(tileCoords, 0, Vector2i(randomOreId,0))
 			_FactoryTiles.set_cell(tileCoords, 0, Vector2i(0,0))
+
+func add_mine_layer(mine_layer: Node) -> void:
+	_VerticalListContainer.add_child(mine_layer)

--- a/Game/player_board.gd
+++ b/Game/player_board.gd
@@ -15,7 +15,6 @@ var player: ConnectionSystem.NetworkPlayer
 # game board properties
 @export var NumCols : int = 30
 @export var LayerThickness : int = 10
-@export var NumMineLayers : int = 1
 @export var SkyHeight : int = 100
 @export var TileMapScale : int = 2
 

--- a/Game/player_board.tscn
+++ b/Game/player_board.tscn
@@ -1,27 +1,14 @@
-[gd_scene load_steps=9 format=3 uid="uid://c5auwrdgqvt1a"]
+[gd_scene load_steps=7 format=3 uid="uid://c5auwrdgqvt1a"]
 
 [ext_resource type="Theme" uid="uid://k1wwefkpb70t" path="res://UI/game_theme.tres" id="1_7uxwk"]
 [ext_resource type="Script" uid="uid://bhx68tgn2jboc" path="res://Game/player_board.gd" id="1_sf1vr"]
-[ext_resource type="Texture2D" uid="uid://b05xviclivy3a" path="res://Assets/ores.png" id="2_7uxwk"]
+[ext_resource type="TileSet" uid="uid://b6a6bt6p5wqq6" path="res://Assets/ores_tileset.tres" id="3_7uxwk"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3kekb"]
 bg_color = Color(0.906971, 0.43494, 0.418012, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jwkme"]
 bg_color = Color(0.357445, 0.631236, 0.823697, 1)
-
-[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_3kekb"]
-texture = ExtResource("2_7uxwk")
-0:0/0 = 0
-1:0/0 = 0
-2:0/0 = 0
-3:0/0 = 0
-4:0/0 = 0
-5:0/0 = 0
-6:0/0 = 0
-
-[sub_resource type="TileSet" id="TileSet_jwkme"]
-sources/0 = SubResource("TileSetAtlasSource_3kekb")
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ps1nv"]
 bg_color = Color(0.497493, 0.654419, 0.410997, 1)
@@ -77,7 +64,7 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_jwkme")
 [node name="FactoryTiles" type="TileMapLayer" parent="VerticalListContainer/FactoryFloor"]
 unique_name_in_owner = true
 scale = Vector2(2, 2)
-tile_set = SubResource("TileSet_jwkme")
+tile_set = ExtResource("3_7uxwk")
 
 [node name="Mine" type="Panel" parent="VerticalListContainer"]
 unique_name_in_owner = true
@@ -89,4 +76,4 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_ps1nv")
 [node name="MineTiles" type="TileMapLayer" parent="VerticalListContainer/Mine"]
 unique_name_in_owner = true
 scale = Vector2(2, 2)
-tile_set = SubResource("TileSet_jwkme")
+tile_set = ExtResource("3_7uxwk")

--- a/Game/player_board.tscn
+++ b/Game/player_board.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://c5auwrdgqvt1a"]
+[gd_scene load_steps=6 format=3 uid="uid://c5auwrdgqvt1a"]
 
 [ext_resource type="Theme" uid="uid://k1wwefkpb70t" path="res://UI/game_theme.tres" id="1_7uxwk"]
 [ext_resource type="Script" uid="uid://bhx68tgn2jboc" path="res://Game/player_board.gd" id="1_sf1vr"]
@@ -9,9 +9,6 @@ bg_color = Color(0.906971, 0.43494, 0.418012, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jwkme"]
 bg_color = Color(0.357445, 0.631236, 0.823697, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ps1nv"]
-bg_color = Color(0.497493, 0.654419, 0.410997, 1)
 
 [node name="PlayerBoard" type="Control"]
 layout_mode = 3
@@ -62,18 +59,6 @@ size_flags_vertical = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_jwkme")
 
 [node name="FactoryTiles" type="TileMapLayer" parent="VerticalListContainer/FactoryFloor"]
-unique_name_in_owner = true
-scale = Vector2(2, 2)
-tile_set = ExtResource("3_7uxwk")
-
-[node name="Mine" type="Panel" parent="VerticalListContainer"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(0, 224)
-layout_mode = 2
-size_flags_vertical = 3
-theme_override_styles/panel = SubResource("StyleBoxFlat_ps1nv")
-
-[node name="MineTiles" type="TileMapLayer" parent="VerticalListContainer/Mine"]
 unique_name_in_owner = true
 scale = Vector2(2, 2)
 tile_set = ExtResource("3_7uxwk")

--- a/Game/world.gd
+++ b/Game/world.gd
@@ -1,6 +1,5 @@
 extends Control
 
-@export var BoardHolder : Node
 @export var PlayerBoard : PackedScene
 @export var MineLayer : PackedScene
 
@@ -15,10 +14,13 @@ var world_seed: int
 var _player_boards: Dictionary[int, Node]
 var _player_ids: Array[int]
 
+@onready var _BoardHolder := %BoardHolder
 @onready var _GameState := %GameState
 @onready var _PlayerStates := %PlayerStates
 @onready var _PlayerSpawner := %PlayerSpawner
 @onready var _ItemDisplay := %ItemDisplay
+
+signal game_ready()
 
 func _ready() -> void:
 	if ConnectionSystem.is_not_running_network():
@@ -37,7 +39,7 @@ func add_player_board(player_id: int) -> void:
 	board.SkyHeight = SkyHeight
 	board.TileMapScale = TileMapScale
 
-	BoardHolder.add_child(board)
+	_BoardHolder.add_child(board)
 	_player_boards[player_id] = board
 
 func init_ores_for_each_player() -> Dictionary[int, Array]:
@@ -93,6 +95,8 @@ func set_up_game(server_world_seed: int) -> void:
 		add_player_board(player_id)
 
 	generate_all_ores()
+
+	game_ready.emit()
 	
 	_ItemDisplay.update_counts()
 

--- a/Game/world.gd
+++ b/Game/world.gd
@@ -3,6 +3,12 @@ extends Control
 @export var BoardHolder : Node
 @export var PlayerBoard : PackedScene
 
+# game board properties
+@export var NumCols: int
+@export var LayerThickness: int
+@export var SkyHeight: int
+@export var TileMapScale: int
+
 var num_players_ready := 0
 
 @onready var _GameState := %GameState
@@ -20,7 +26,13 @@ func _ready() -> void:
 	
 func add_player_board(player_id: int) -> void:
 	var board = PlayerBoard.instantiate()
+
 	board.owner_id = player_id
+	board.NumCols = NumCols
+	board.LayerThickness = LayerThickness
+	board.SkyHeight = SkyHeight
+	board.TileMapScale = TileMapScale
+
 	BoardHolder.add_child(board)
 
 @rpc("call_local", "reliable")

--- a/Game/world.gd
+++ b/Game/world.gd
@@ -2,6 +2,7 @@ extends Control
 
 @export var BoardHolder : Node
 @export var PlayerBoard : PackedScene
+@export var MineLayer : PackedScene
 
 # game board properties
 @export var NumCols: int
@@ -10,6 +11,7 @@ extends Control
 @export var TileMapScale: int
 
 var num_players_ready := 0
+var _player_boards: Dictionary[int, Node]
 
 @onready var _GameState := %GameState
 @onready var _PlayerStates := %PlayerStates
@@ -34,6 +36,49 @@ func add_player_board(player_id: int) -> void:
 	board.TileMapScale = TileMapScale
 
 	BoardHolder.add_child(board)
+	_player_boards[player_id] = board
+
+func init_ores_for_each_player(player_ids: Array[int]) -> Dictionary[int, Array]:
+	# note: nested types are disallowed, so must be Array instead of Array[OreGenerationResource]
+	var ores_for_each_player: Dictionary[int, Array]
+	for player_id in player_ids:
+		ores_for_each_player[player_id] = []
+	return ores_for_each_player
+
+
+func generate_all_ores(player_ids: Array[int]) -> void:
+	for layer_num in range(Ores.get_num_mine_layers()):
+		var layer_gen_data := Ores.get_layer_generation_data(layer_num)
+		var background_rock := layer_gen_data.background_rock
+		var ores_for_each_player := init_ores_for_each_player(player_ids)
+		var players_not_chosen_yet := player_ids.duplicate()
+
+		# for each ore generation data in this layer
+		for ore_gen_data in layer_gen_data.ores:
+			if ore_gen_data.generate_for_all_players:
+				# if it's for all players, add it for all players
+				for player_id in player_ids:
+					ores_for_each_player[player_id].append(ore_gen_data)
+			else:
+				# otherwise, assign it to a player that hasn't gotten a random ore yet
+				players_not_chosen_yet.shuffle()
+				var random_player: int = players_not_chosen_yet.pop_back()
+				ores_for_each_player[random_player].append(ore_gen_data)
+				# if we've assigned a random ore to each player at least once, do it again
+				if players_not_chosen_yet.size() == 0:
+					players_not_chosen_yet = player_ids.duplicate()
+		
+		# actually generate and add the ore boards to each player
+		for player_id in player_ids:
+			var mine_layer = MineLayer.instantiate()
+			mine_layer.num_rows = LayerThickness
+			mine_layer.num_cols = NumCols
+			mine_layer.tile_map_scale = TileMapScale
+			_player_boards[player_id].add_mine_layer(mine_layer)
+
+			var player_ore_gen_data := ores_for_each_player[player_id]
+			mine_layer.generate_ores(background_rock, player_ore_gen_data)
+
 
 @rpc("call_local", "reliable")
 func set_up_game(world_seed: int) -> void:
@@ -44,6 +89,8 @@ func set_up_game(world_seed: int) -> void:
 	for player_id in player_ids:
 		var player = ConnectionSystem.get_player(player_id)
 		add_player_board(player_id)
+
+	generate_all_ores(player_ids)	
 	
 	_ItemDisplay.update_counts()
 

--- a/Game/world.tscn
+++ b/Game/world.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=14 format=3 uid="uid://dji12mak03hku"]
+[gd_scene load_steps=15 format=3 uid="uid://dji12mak03hku"]
 
 [ext_resource type="Script" uid="uid://cokmj1q7s6ab7" path="res://Game/world.gd" id="1_3kekb"]
 [ext_resource type="Theme" uid="uid://k1wwefkpb70t" path="res://UI/game_theme.tres" id="1_pecy7"]
 [ext_resource type="PackedScene" uid="uid://c5auwrdgqvt1a" path="res://Game/player_board.tscn" id="2_3kekb"]
 [ext_resource type="Script" uid="uid://b27jsrdl1j57m" path="res://Game/data/game_state.gd" id="3_jwkme"]
 [ext_resource type="Script" uid="uid://dxkqib41uryfs" path="res://Game/item_display.gd" id="3_ps1nv"]
+[ext_resource type="PackedScene" uid="uid://drw5syeijuvky" path="res://Game/mine_layer.tscn" id="4_16ps5"]
 [ext_resource type="PackedScene" uid="uid://fcbjc5acubwe" path="res://Game/item_display_row.tscn" id="4_ho6sb"]
 [ext_resource type="Script" uid="uid://dhc518iykwv14" path="res://Game/player_states.gd" id="6_4ncwh"]
 [ext_resource type="PackedScene" uid="uid://cho1mjxxemfva" path="res://Game/cheat_items.tscn" id="6_hvno2"]
@@ -33,9 +34,9 @@ theme = ExtResource("1_pecy7")
 script = ExtResource("1_3kekb")
 BoardHolder = NodePath("SplitContainer/Asteroid/ScrollContainer/Board Holder")
 PlayerBoard = ExtResource("2_3kekb")
+MineLayer = ExtResource("4_16ps5")
 NumCols = 10
 LayerThickness = 7
-NumMineLayers = 1
 SkyHeight = 300
 TileMapScale = 2
 

--- a/Game/world.tscn
+++ b/Game/world.tscn
@@ -23,7 +23,7 @@ properties/0/path = NodePath("GameState:example_int")
 properties/0/spawn = true
 properties/0/replication_mode = 1
 
-[node name="World" type="Control" node_paths=PackedStringArray("BoardHolder")]
+[node name="World" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -32,7 +32,6 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_pecy7")
 script = ExtResource("1_3kekb")
-BoardHolder = NodePath("SplitContainer/Asteroid/ScrollContainer/Board Holder")
 PlayerBoard = ExtResource("2_3kekb")
 MineLayer = ExtResource("4_16ps5")
 NumCols = 10
@@ -65,7 +64,8 @@ layout_mode = 2
 size_flags_horizontal = 4
 theme_override_styles/panel = SubResource("StyleBoxFlat_3kekb")
 
-[node name="Board Holder" type="HBoxContainer" parent="SplitContainer/Asteroid/ScrollContainer"]
+[node name="BoardHolder" type="HBoxContainer" parent="SplitContainer/Asteroid/ScrollContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="SplitContainer/Asteroid"]
@@ -95,8 +95,26 @@ size_flags_horizontal = 0
 size_flags_vertical = 0
 script = ExtResource("6_r7jf0")
 
-[node name="CheatItems" parent="SplitContainer/Asteroid/VBoxContainer/DebugMenu" instance=ExtResource("6_hvno2")]
+[node name="VBoxContainer" type="VBoxContainer" parent="SplitContainer/Asteroid/VBoxContainer/DebugMenu"]
 layout_mode = 2
+
+[node name="CheatItems" parent="SplitContainer/Asteroid/VBoxContainer/DebugMenu/VBoxContainer" instance=ExtResource("6_hvno2")]
+layout_mode = 2
+
+[node name="WorldGen" type="MarginContainer" parent="SplitContainer/Asteroid/VBoxContainer/DebugMenu/VBoxContainer"]
+layout_mode = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="SplitContainer/Asteroid/VBoxContainer/DebugMenu/VBoxContainer/WorldGen"]
+layout_mode = 2
+
+[node name="SeedText" type="Label" parent="SplitContainer/Asteroid/VBoxContainer/DebugMenu/VBoxContainer/WorldGen/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Seed: 12344567"
+
+[node name="RegenWorldButton" type="Button" parent="SplitContainer/Asteroid/VBoxContainer/DebugMenu/VBoxContainer/WorldGen/VBoxContainer"]
+layout_mode = 2
+text = "Regenerate World"
 
 [node name="GameState" type="Node" parent="."]
 unique_name_in_owner = true
@@ -115,4 +133,6 @@ _spawnable_scenes = PackedStringArray("uid://b47vu2y258g5v")
 spawn_path = NodePath("../PlayerStates")
 spawn_limit = 3
 
-[connection signal="add_items" from="SplitContainer/Asteroid/VBoxContainer/DebugMenu/CheatItems" to="SplitContainer/Asteroid/VBoxContainer/DebugMenu" method="_on_cheat_items_add_items"]
+[connection signal="game_ready" from="." to="SplitContainer/Asteroid/VBoxContainer/DebugMenu" method="_on_world_game_ready"]
+[connection signal="add_items" from="SplitContainer/Asteroid/VBoxContainer/DebugMenu/VBoxContainer/CheatItems" to="SplitContainer/Asteroid/VBoxContainer/DebugMenu" method="_on_cheat_items_add_items"]
+[connection signal="pressed" from="SplitContainer/Asteroid/VBoxContainer/DebugMenu/VBoxContainer/WorldGen/VBoxContainer/RegenWorldButton" to="SplitContainer/Asteroid/VBoxContainer/DebugMenu" method="_on_regen_world_button_pressed"]

--- a/Game/world.tscn
+++ b/Game/world.tscn
@@ -33,6 +33,11 @@ theme = ExtResource("1_pecy7")
 script = ExtResource("1_3kekb")
 BoardHolder = NodePath("SplitContainer/Asteroid/ScrollContainer/Board Holder")
 PlayerBoard = ExtResource("2_3kekb")
+NumCols = 10
+LayerThickness = 7
+NumMineLayers = 1
+SkyHeight = 300
+TileMapScale = 2
 
 [node name="SplitContainer" type="HSplitContainer" parent="."]
 layout_mode = 1

--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,7 @@ UiUtils="*res://UI/utils.gd"
 Globals="*res://globals.gd"
 ConnectionSystem="*res://Systems/connection.gd"
 Items="*res://Game/items.tscn"
+Ores="*res://Game/ores.tscn"
 
 [display]
 

--- a/resource_list_data.tres
+++ b/resource_list_data.tres
@@ -1,9 +1,10 @@
-[gd_resource type="Resource" script_class="ResourceListData" load_steps=7 format=3 uid="uid://dylcpxpn33g71"]
+[gd_resource type="Resource" script_class="ResourceListData" load_steps=9 format=3 uid="uid://dylcpxpn33g71"]
 
 [ext_resource type="Script" uid="uid://b2v70ie1xv58a" path="res://addons/resource_list/resource_list_datum.gd" id="1_k568v"]
 [ext_resource type="Script" uid="uid://dmnwciefckrau" path="res://Game/data/building_resource.gd" id="2_dka42"]
 [ext_resource type="Script" uid="uid://cudy3ci3kelwu" path="res://addons/resource_list/resource_list_data.gd" id="3_62ssh"]
 [ext_resource type="Script" uid="uid://c2bq2stnv5anq" path="res://Game/data/item_resource.gd" id="3_dka42"]
+[ext_resource type="Script" uid="uid://vkrp2p2gvhjj" path="res://Game/data/ore_resource.gd" id="4_62ssh"]
 
 [sub_resource type="Resource" id="Resource_nlw5f"]
 script = ExtResource("1_k568v")
@@ -19,6 +20,13 @@ base_resource_script = ExtResource("3_dka42")
 resource_dir_path = "res://Game/data/items"
 metadata/_custom_type_script = "uid://b2v70ie1xv58a"
 
+[sub_resource type="Resource" id="Resource_wtt5h"]
+script = ExtResource("1_k568v")
+type = "ore"
+base_resource_script = ExtResource("4_62ssh")
+resource_dir_path = "res://Game/data/ores"
+metadata/_custom_type_script = "uid://b2v70ie1xv58a"
+
 [resource]
 script = ExtResource("3_62ssh")
-resources_data = Array[ExtResource("1_k568v")]([SubResource("Resource_nlw5f"), SubResource("Resource_62ssh")])
+resources_data = Array[ExtResource("1_k568v")]([SubResource("Resource_nlw5f"), SubResource("Resource_62ssh"), SubResource("Resource_wtt5h")])


### PR DESCRIPTION
- Closes #12 
- Closes #13 
- Closes #64
- `Ores` stores ore information and ore generation information
- `Ore.Type` stores possible ores
- `OreResource` is fully integrated with Resource List
- Ore generation information is fully customizable through `ores.tscn`, including how many layers, what ores go on what layer, background rock, and a lot more
- The ore generation algorithm works as follows: for each layer,
  1. figure out which ores need to be generated on that layer
  2. divide the ores among the players: ores that need to be on all players will be given to all players, otherwise randomly assign ores to players evenly until they are all distributed
  3. for each player, generate an ore board containing their ores for that layer
      1. for each ore, pick a random point in the board
      2. pick a random radius for each ore, related to the size
      3. for each tile in the space, if it is within the radius of an ore center point, paint that tile with that ore. if it is in the radius of multiple ores, pick the closest. if it is in the radius of no ores, paint it with background rock
- Added world seed display to debug menu, as well as ability to regenerate the world with a new seed

TODO:
- currently, the ore generation algorithm just writes directly to tilemaplayers rather than storing a copy in memory. Making a copy to store for easy lookup in memory might be nice
- improve the ore generation algorithm, perhaps by using FastNoiseLite noise layers
- make the generation parameters fully editable inside the game
