### PR TITLE
fix removing buildings not working/duplicating resources

### DIFF
--- a/Game/model/player_state/building_model.gd
+++ b/Game/model/player_state/building_model.gd
@@ -7,6 +7,7 @@ extends Node
 ## Array of buildings turned into primitives that is synchronized with MultiplayerSynchronizer.
 @export var buildings_serialized: Array[Dictionary]
 
+# TODO: rewrite to have buildings be either the shadow server copy or the client copy
 ## Array of buildings, stored internally.
 var buildings: Array[BuildingEntity]
 
@@ -23,11 +24,18 @@ var _next_building_unique_id: int = 0
 
 ## Return the building at the given position, if it exists.
 func get_building_at_pos(grid_position: Vector2i) -> BuildingEntity:
-	var index: int = buildings.find_custom(
+	# TODO: rewrite this
+	var buildings_to_use: Array[BuildingEntity]
+	if multiplayer.is_server():
+		buildings_to_use = _buildings_shadow
+	else:
+		buildings_to_use = buildings
+
+	var index: int = buildings_to_use.find_custom(
 		func(elem): return elem.position == grid_position
 	)
 	if index != -1:
-		return buildings[index]
+		return buildings_to_use[index]
 	else:
 		return null
 
@@ -50,6 +58,7 @@ func get_all() -> Array[BuildingEntity]:
 
 ## Add a building to the model.
 func add_building(grid_position: Vector2i, building_id: String) -> BuildingEntity:
+	print_debug("adding building id %d" % _next_building_unique_id)
 	var building: BuildingEntity = BuildingEntity.new(
 		_next_building_unique_id,
 		_player_id,
@@ -63,6 +72,7 @@ func add_building(grid_position: Vector2i, building_id: String) -> BuildingEntit
 
 ## Remove a building from the model.
 func remove_building(unique_id: int) -> void:
+	print_debug("removing building id %d" % unique_id)
 	var index_to_remove = _buildings_shadow.find_custom(
 		func(elem): return elem.unique_id == unique_id
 	)

--- a/Game/model/player_state/player_state.gd
+++ b/Game/model/player_state/player_state.gd
@@ -67,6 +67,7 @@ func remove_building(tile_position: Vector2i) -> bool:
 	assert(multiplayer.is_server())
 	var building_at_pos = buildings.get_building_at_pos(tile_position)
 	if building_at_pos:
+		buildings.remove_building(building_at_pos.unique_id)
 		ComponentManager.remove_components_building(building_at_pos)
 		return true
 	else:

--- a/Game/ui/asteroid area/asteroid.gd
+++ b/Game/ui/asteroid area/asteroid.gd
@@ -186,6 +186,7 @@ func request_place_building(grid_position: Vector2i, building: String) -> void:
 ## If it should, actually place the building for both players.
 @rpc("any_peer", "call_local", "reliable")
 func process_place_building(grid_position: Vector2i, building: String) -> void:
+	assert(multiplayer.is_server())
 	var caller_id := multiplayer.get_remote_sender_id()
 	print("processing place building from %d" % caller_id)
 	if Model.can_build_at_location(building, caller_id, grid_position):
@@ -205,6 +206,7 @@ func request_remove_building(grid_position: Vector2i) -> void:
 ## If it should, actually remove the building for both players.
 @rpc("any_peer", "call_local", "reliable")
 func process_remove_building(grid_position: Vector2i) -> void:
+	assert(multiplayer.is_server())
 	var caller_id := multiplayer.get_remote_sender_id()
 	print("processing remove building from %d" % caller_id)
 	if Model.can_remove_building(caller_id, grid_position):


### PR DESCRIPTION
- removing buildings now actually removes the building
- there was an item duplication exploit caused by a desync on reading from real/writing to shadow. I have a better idea on how to implement this, but I'm not doing it right now.

Idea: Each property has a "server" version and a "client" version. The server version is the equivalent of shadow right now, and the client version is what is synchronized from the network. Then the actual value of the property is the server version if you're the server, and the client version if you're the client. Then any reads are done from the up-to-date server version if you're the server, and the client version if you're the client. This also means you don't need any "get_shadow" type functions.